### PR TITLE
Update files with app template in Xcode 26 beta

### DIFF
--- a/Northstar Demo.xcodeproj/project.pbxproj
+++ b/Northstar Demo.xcodeproj/project.pbxproj
@@ -7,40 +7,40 @@
 	objects = {
 
 /* Begin PBXContainerItemProxy section */
-		E159F40D2DFAFEF900963919 /* PBXContainerItemProxy */ = {
+		E1E6A50C2E003BA6008C737D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E159F3F72DFAFEF900963919 /* Project object */;
+			containerPortal = E1E6A4F62E003BA5008C737D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E159F3FE2DFAFEF900963919;
+			remoteGlobalIDString = E1E6A4FD2E003BA5008C737D;
 			remoteInfo = "Northstar Demo";
 		};
-		E159F4172DFAFEF900963919 /* PBXContainerItemProxy */ = {
+		E1E6A5162E003BA6008C737D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E159F3F72DFAFEF900963919 /* Project object */;
+			containerPortal = E1E6A4F62E003BA5008C737D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E159F3FE2DFAFEF900963919;
+			remoteGlobalIDString = E1E6A4FD2E003BA5008C737D;
 			remoteInfo = "Northstar Demo";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		E159F3FF2DFAFEF900963919 /* Northstar Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Northstar Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E159F40C2DFAFEF900963919 /* Northstar DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E159F4162DFAFEF900963919 /* Northstar DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1E6A4FE2E003BA5008C737D /* Northstar Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Northstar Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1E6A50B2E003BA6008C737D /* Northstar DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1E6A5152E003BA6008C737D /* Northstar DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		E159F4012DFAFEF900963919 /* Northstar Demo */ = {
+		E1E6A5002E003BA5008C737D /* Northstar Demo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Northstar Demo";
 			sourceTree = "<group>";
 		};
-		E159F40F2DFAFEF900963919 /* Northstar DemoTests */ = {
+		E1E6A50E2E003BA6008C737D /* Northstar DemoTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Northstar DemoTests";
 			sourceTree = "<group>";
 		};
-		E159F4192DFAFEF900963919 /* Northstar DemoUITests */ = {
+		E1E6A5182E003BA6008C737D /* Northstar DemoUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Northstar DemoUITests";
 			sourceTree = "<group>";
@@ -48,21 +48,21 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		E159F3FC2DFAFEF900963919 /* Frameworks */ = {
+		E1E6A4FB2E003BA5008C737D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F4092DFAFEF900963919 /* Frameworks */ = {
+		E1E6A5082E003BA6008C737D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F4132DFAFEF900963919 /* Frameworks */ = {
+		E1E6A5122E003BA6008C737D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -72,22 +72,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		E159F3F62DFAFEF900963919 = {
+		E1E6A4F52E003BA5008C737D = {
 			isa = PBXGroup;
 			children = (
-				E159F4012DFAFEF900963919 /* Northstar Demo */,
-				E159F40F2DFAFEF900963919 /* Northstar DemoTests */,
-				E159F4192DFAFEF900963919 /* Northstar DemoUITests */,
-				E159F4002DFAFEF900963919 /* Products */,
+				E1E6A5002E003BA5008C737D /* Northstar Demo */,
+				E1E6A50E2E003BA6008C737D /* Northstar DemoTests */,
+				E1E6A5182E003BA6008C737D /* Northstar DemoUITests */,
+				E1E6A4FF2E003BA5008C737D /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		E159F4002DFAFEF900963919 /* Products */ = {
+		E1E6A4FF2E003BA5008C737D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				E159F3FF2DFAFEF900963919 /* Northstar Demo.app */,
-				E159F40C2DFAFEF900963919 /* Northstar DemoTests.xctest */,
-				E159F4162DFAFEF900963919 /* Northstar DemoUITests.xctest */,
+				E1E6A4FE2E003BA5008C737D /* Northstar Demo.app */,
+				E1E6A50B2E003BA6008C737D /* Northstar DemoTests.xctest */,
+				E1E6A5152E003BA6008C737D /* Northstar DemoUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -95,134 +95,134 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		E159F3FE2DFAFEF900963919 /* Northstar Demo */ = {
+		E1E6A4FD2E003BA5008C737D /* Northstar Demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E159F4202DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar Demo" */;
+			buildConfigurationList = E1E6A51F2E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar Demo" */;
 			buildPhases = (
-				E159F3FB2DFAFEF900963919 /* Sources */,
-				E159F3FC2DFAFEF900963919 /* Frameworks */,
-				E159F3FD2DFAFEF900963919 /* Resources */,
+				E1E6A4FA2E003BA5008C737D /* Sources */,
+				E1E6A4FB2E003BA5008C737D /* Frameworks */,
+				E1E6A4FC2E003BA5008C737D /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				E159F4012DFAFEF900963919 /* Northstar Demo */,
+				E1E6A5002E003BA5008C737D /* Northstar Demo */,
 			);
 			name = "Northstar Demo";
 			packageProductDependencies = (
 			);
 			productName = "Northstar Demo";
-			productReference = E159F3FF2DFAFEF900963919 /* Northstar Demo.app */;
+			productReference = E1E6A4FE2E003BA5008C737D /* Northstar Demo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		E159F40B2DFAFEF900963919 /* Northstar DemoTests */ = {
+		E1E6A50A2E003BA6008C737D /* Northstar DemoTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E159F4232DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar DemoTests" */;
+			buildConfigurationList = E1E6A5222E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar DemoTests" */;
 			buildPhases = (
-				E159F4082DFAFEF900963919 /* Sources */,
-				E159F4092DFAFEF900963919 /* Frameworks */,
-				E159F40A2DFAFEF900963919 /* Resources */,
+				E1E6A5072E003BA6008C737D /* Sources */,
+				E1E6A5082E003BA6008C737D /* Frameworks */,
+				E1E6A5092E003BA6008C737D /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				E159F40E2DFAFEF900963919 /* PBXTargetDependency */,
+				E1E6A50D2E003BA6008C737D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				E159F40F2DFAFEF900963919 /* Northstar DemoTests */,
+				E1E6A50E2E003BA6008C737D /* Northstar DemoTests */,
 			);
 			name = "Northstar DemoTests";
 			packageProductDependencies = (
 			);
 			productName = "Northstar DemoTests";
-			productReference = E159F40C2DFAFEF900963919 /* Northstar DemoTests.xctest */;
+			productReference = E1E6A50B2E003BA6008C737D /* Northstar DemoTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		E159F4152DFAFEF900963919 /* Northstar DemoUITests */ = {
+		E1E6A5142E003BA6008C737D /* Northstar DemoUITests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E159F4262DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar DemoUITests" */;
+			buildConfigurationList = E1E6A5252E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar DemoUITests" */;
 			buildPhases = (
-				E159F4122DFAFEF900963919 /* Sources */,
-				E159F4132DFAFEF900963919 /* Frameworks */,
-				E159F4142DFAFEF900963919 /* Resources */,
+				E1E6A5112E003BA6008C737D /* Sources */,
+				E1E6A5122E003BA6008C737D /* Frameworks */,
+				E1E6A5132E003BA6008C737D /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				E159F4182DFAFEF900963919 /* PBXTargetDependency */,
+				E1E6A5172E003BA6008C737D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				E159F4192DFAFEF900963919 /* Northstar DemoUITests */,
+				E1E6A5182E003BA6008C737D /* Northstar DemoUITests */,
 			);
 			name = "Northstar DemoUITests";
 			packageProductDependencies = (
 			);
 			productName = "Northstar DemoUITests";
-			productReference = E159F4162DFAFEF900963919 /* Northstar DemoUITests.xctest */;
+			productReference = E1E6A5152E003BA6008C737D /* Northstar DemoUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		E159F3F72DFAFEF900963919 /* Project object */ = {
+		E1E6A4F62E003BA5008C737D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1640;
-				LastUpgradeCheck = 1640;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
 				TargetAttributes = {
-					E159F3FE2DFAFEF900963919 = {
-						CreatedOnToolsVersion = 16.4;
+					E1E6A4FD2E003BA5008C737D = {
+						CreatedOnToolsVersion = 26.0;
 					};
-					E159F40B2DFAFEF900963919 = {
-						CreatedOnToolsVersion = 16.4;
-						TestTargetID = E159F3FE2DFAFEF900963919;
+					E1E6A50A2E003BA6008C737D = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = E1E6A4FD2E003BA5008C737D;
 					};
-					E159F4152DFAFEF900963919 = {
-						CreatedOnToolsVersion = 16.4;
-						TestTargetID = E159F3FE2DFAFEF900963919;
+					E1E6A5142E003BA6008C737D = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = E1E6A4FD2E003BA5008C737D;
 					};
 				};
 			};
-			buildConfigurationList = E159F3FA2DFAFEF900963919 /* Build configuration list for PBXProject "Northstar Demo" */;
+			buildConfigurationList = E1E6A4F92E003BA5008C737D /* Build configuration list for PBXProject "Northstar Demo" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
 			);
-			mainGroup = E159F3F62DFAFEF900963919;
+			mainGroup = E1E6A4F52E003BA5008C737D;
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
-			productRefGroup = E159F4002DFAFEF900963919 /* Products */;
+			productRefGroup = E1E6A4FF2E003BA5008C737D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				E159F3FE2DFAFEF900963919 /* Northstar Demo */,
-				E159F40B2DFAFEF900963919 /* Northstar DemoTests */,
-				E159F4152DFAFEF900963919 /* Northstar DemoUITests */,
+				E1E6A4FD2E003BA5008C737D /* Northstar Demo */,
+				E1E6A50A2E003BA6008C737D /* Northstar DemoTests */,
+				E1E6A5142E003BA6008C737D /* Northstar DemoUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		E159F3FD2DFAFEF900963919 /* Resources */ = {
+		E1E6A4FC2E003BA5008C737D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F40A2DFAFEF900963919 /* Resources */ = {
+		E1E6A5092E003BA6008C737D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F4142DFAFEF900963919 /* Resources */ = {
+		E1E6A5132E003BA6008C737D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -232,21 +232,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		E159F3FB2DFAFEF900963919 /* Sources */ = {
+		E1E6A4FA2E003BA5008C737D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F4082DFAFEF900963919 /* Sources */ = {
+		E1E6A5072E003BA6008C737D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E159F4122DFAFEF900963919 /* Sources */ = {
+		E1E6A5112E003BA6008C737D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -256,20 +256,20 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		E159F40E2DFAFEF900963919 /* PBXTargetDependency */ = {
+		E1E6A50D2E003BA6008C737D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = E159F3FE2DFAFEF900963919 /* Northstar Demo */;
-			targetProxy = E159F40D2DFAFEF900963919 /* PBXContainerItemProxy */;
+			target = E1E6A4FD2E003BA5008C737D /* Northstar Demo */;
+			targetProxy = E1E6A50C2E003BA6008C737D /* PBXContainerItemProxy */;
 		};
-		E159F4182DFAFEF900963919 /* PBXTargetDependency */ = {
+		E1E6A5172E003BA6008C737D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = E159F3FE2DFAFEF900963919 /* Northstar Demo */;
-			targetProxy = E159F4172DFAFEF900963919 /* PBXContainerItemProxy */;
+			target = E1E6A4FD2E003BA5008C737D /* Northstar Demo */;
+			targetProxy = E1E6A5162E003BA6008C737D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		E159F41E2DFAFEF900963919 /* Debug */ = {
+		E1E6A51D2E003BA6008C737D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -322,7 +322,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -333,7 +333,7 @@
 			};
 			name = Debug;
 		};
-		E159F41F2DFAFEF900963919 /* Release */ = {
+		E1E6A51E2E003BA6008C737D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -380,7 +380,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -390,7 +390,7 @@
 			};
 			name = Release;
 		};
-		E159F4212DFAFEF900963919 /* Debug */ = {
+		E1E6A5202E003BA6008C737D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -412,13 +412,16 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		E159F4222DFAFEF900963919 /* Release */ = {
+		E1E6A5212E003BA6008C737D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -440,13 +443,16 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
-		E159F4242DFAFEF900963919 /* Debug */ = {
+		E1E6A5232E003BA6008C737D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -454,18 +460,20 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CR78ZDZ2ND;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-DemoTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Northstar Demo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Northstar Demo";
 			};
 			name = Debug;
 		};
-		E159F4252DFAFEF900963919 /* Release */ = {
+		E1E6A5242E003BA6008C737D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -473,18 +481,20 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CR78ZDZ2ND;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-DemoTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Northstar Demo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Northstar Demo";
 			};
 			name = Release;
 		};
-		E159F4272DFAFEF900963919 /* Debug */ = {
+		E1E6A5262E003BA6008C737D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -494,14 +504,16 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-DemoUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "Northstar Demo";
 			};
 			name = Debug;
 		};
-		E159F4282DFAFEF900963919 /* Release */ = {
+		E1E6A5272E003BA6008C737D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -511,7 +523,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walkbase.Northstar-DemoUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "Northstar Demo";
@@ -521,43 +535,43 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		E159F3FA2DFAFEF900963919 /* Build configuration list for PBXProject "Northstar Demo" */ = {
+		E1E6A4F92E003BA5008C737D /* Build configuration list for PBXProject "Northstar Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E159F41E2DFAFEF900963919 /* Debug */,
-				E159F41F2DFAFEF900963919 /* Release */,
+				E1E6A51D2E003BA6008C737D /* Debug */,
+				E1E6A51E2E003BA6008C737D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E159F4202DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar Demo" */ = {
+		E1E6A51F2E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E159F4212DFAFEF900963919 /* Debug */,
-				E159F4222DFAFEF900963919 /* Release */,
+				E1E6A5202E003BA6008C737D /* Debug */,
+				E1E6A5212E003BA6008C737D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E159F4232DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar DemoTests" */ = {
+		E1E6A5222E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar DemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E159F4242DFAFEF900963919 /* Debug */,
-				E159F4252DFAFEF900963919 /* Release */,
+				E1E6A5232E003BA6008C737D /* Debug */,
+				E1E6A5242E003BA6008C737D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E159F4262DFAFEF900963919 /* Build configuration list for PBXNativeTarget "Northstar DemoUITests" */ = {
+		E1E6A5252E003BA6008C737D /* Build configuration list for PBXNativeTarget "Northstar DemoUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E159F4272DFAFEF900963919 /* Debug */,
-				E159F4282DFAFEF900963919 /* Release */,
+				E1E6A5262E003BA6008C737D /* Debug */,
+				E1E6A5272E003BA6008C737D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = E159F3F72DFAFEF900963919 /* Project object */;
+	rootObject = E1E6A4F62E003BA5008C737D /* Project object */;
 }


### PR DESCRIPTION
I scaffolded a new project with the same information in Xcode 26 Beta (downloaded [here](https://developer.apple.com/download/applications/)) and replaced the project files. Only `project.pbxproj` had some changes; the rest remained unchanged.