### PR TITLE
Ignore workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ playground.xcworkspace
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 # Pods/
 # Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
+*.xcworkspace
 
 # Carthage
 # Add this line if you want to avoid checking in source code from Carthage dependencies.


### PR DESCRIPTION
Workspace-related files are auto-generated in an Xcode project even if you aren't using a workspace.