### PR TITLE
Indicate no encryption

### DIFF
--- a/Northstar Demo.xcodeproj/project.pbxproj
+++ b/Northstar Demo.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 				DEVELOPMENT_TEAM = CR78ZDZ2ND;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -432,6 +433,7 @@
 				DEVELOPMENT_TEAM = CR78ZDZ2ND;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
You need to comply with using encryption algorithms every time you upload a build to TestFlight:
![image](https://github.com/user-attachments/assets/23bf38be-e6e4-4678-8638-acc9e9a2cd43)

As said in the message, you can modify `Info.plist` to avoid answering the same question for every build.