### PR TITLE
Revert "Add a first build of the Northstar SDK"

### DIFF
--- a/Northstar Demo.xcodeproj/project.pbxproj
+++ b/Northstar Demo.xcodeproj/project.pbxproj
@@ -6,19 +6,7 @@
 	objectVersion = 77;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		E10482862E0AA8D2001AC875 /* Northstar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10482832E0AA8C3001AC875 /* Northstar.framework */; };
-		E10482872E0AA8D2001AC875 /* Northstar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E10482832E0AA8C3001AC875 /* Northstar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-/* End PBXBuildFile section */
-
 /* Begin PBXContainerItemProxy section */
-		E10482822E0AA8C3001AC875 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E10482772E0AA8C3001AC875 /* Northstar.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E1E6A64B2E030E65008C737D;
-			remoteInfo = Northstar;
-		};
 		E1E6A50C2E003BA6008C737D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E1E6A4F62E003BA5008C737D /* Project object */;
@@ -35,22 +23,7 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		E10482882E0AA8D2001AC875 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				E10482872E0AA8D2001AC875 /* Northstar.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
-		E10482772E0AA8C3001AC875 /* Northstar.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Northstar.xcodeproj; path = "../northstar-ios/Northstar.xcodeproj"; sourceTree = "<group>"; };
 		E1E6A4FE2E003BA5008C737D /* Northstar Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Northstar Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1E6A50B2E003BA6008C737D /* Northstar DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1E6A5152E003BA6008C737D /* Northstar DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Northstar DemoUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,7 +52,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E10482862E0AA8D2001AC875 /* Northstar.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,29 +72,12 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		E10482762E0AA8C3001AC875 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				E10482772E0AA8C3001AC875 /* Northstar.xcodeproj */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E10482782E0AA8C3001AC875 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E10482832E0AA8C3001AC875 /* Northstar.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		E1E6A4F52E003BA5008C737D = {
 			isa = PBXGroup;
 			children = (
 				E1E6A5002E003BA5008C737D /* Northstar Demo */,
 				E1E6A50E2E003BA6008C737D /* Northstar DemoTests */,
 				E1E6A5182E003BA6008C737D /* Northstar DemoUITests */,
-				E10482762E0AA8C3001AC875 /* Frameworks */,
 				E1E6A4FF2E003BA5008C737D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -147,7 +102,6 @@
 				E1E6A4FA2E003BA5008C737D /* Sources */,
 				E1E6A4FB2E003BA5008C737D /* Frameworks */,
 				E1E6A4FC2E003BA5008C737D /* Resources */,
-				E10482882E0AA8D2001AC875 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -244,12 +198,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E1E6A4FF2E003BA5008C737D /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = E10482782E0AA8C3001AC875 /* Products */;
-					ProjectRef = E10482772E0AA8C3001AC875 /* Northstar.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				E1E6A4FD2E003BA5008C737D /* Northstar Demo */,
@@ -258,16 +206,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		E10482832E0AA8C3001AC875 /* Northstar.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Northstar.framework;
-			remoteRef = E10482822E0AA8C3001AC875 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E1E6A4FC2E003BA5008C737D /* Resources */ = {

--- a/Northstar Demo/ContentView.swift
+++ b/Northstar Demo/ContentView.swift
@@ -1,21 +1,12 @@
-import Northstar
 import SwiftUI
 
 struct ContentView: View {
-    private let positioning = WalkbasePositioning()
     var body: some View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
-            Button("SDK test") {
-                positioning.test()
-            }
-            .padding()
-            .background(.blue)
-            .foregroundStyle(.white)
-            .clipShape(.capsule)
         }
         .padding()
     }


### PR DESCRIPTION
Reverts Walkbase/northstar-ios-demo#15

The build in Xcode Cloud failed with the following error:
![image](https://github.com/user-attachments/assets/cd92eac5-30e1-44db-ae2a-18ba7c745d7c)

My first thought was to add the built `.framework` to the project so that there would be two `Northstar.framework` files. If the linked framework is available, we'd use that; otherwise, we fall back to the built version. I could not get this working, though, with any of these combinations:
![image](https://github.com/user-attachments/assets/29ffa98f-0f2f-4223-8db1-22a06f4e49ac)