### PR TITLE
Bump minimum deployment target to iOS 18

### DIFF
--- a/Northstar Demo.xcodeproj/project.pbxproj
+++ b/Northstar Demo.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -501,7 +501,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
According to [this MacRumors article](https://www.macrumors.com/2025/06/05/ios-18-adoption-numbers-june/?utm_source=chatgpt.com), iOS 18 is installed on 88 percent of iPhones released in the last four years and 82 percent of all iPhones. This percentage is high enough to bump our minimum target to that version.

Some patterns in Swift/SwiftUI, like the one below, are mentioned in the Swift documentation and only work on iOS 18 and above.

```swift
TabView {
  Tab("Home", systemImage: "house") {
    // ...
  }
}
```

Finding alternative older patterns takes time, and if we are not under any obligation to target an older iOS version, we should target iOS 18.