### PR TITLE
Suppress OS activity error logs

### DIFF
--- a/Northstar Demo.xcodeproj/xcshareddata/xcschemes/Northstar Demo.xcscheme
+++ b/Northstar Demo.xcodeproj/xcshareddata/xcschemes/Northstar Demo.xcscheme
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1E6A4FD2E003BA5008C737D"
+               BuildableName = "Northstar Demo.app"
+               BlueprintName = "Northstar Demo"
+               ReferencedContainer = "container:Northstar Demo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1E6A50A2E003BA6008C737D"
+               BuildableName = "Northstar DemoTests.xctest"
+               BlueprintName = "Northstar DemoTests"
+               ReferencedContainer = "container:Northstar Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1E6A5142E003BA6008C737D"
+               BuildableName = "Northstar DemoUITests.xctest"
+               BlueprintName = "Northstar DemoUITests"
+               ReferencedContainer = "container:Northstar Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1E6A4FD2E003BA5008C737D"
+            BuildableName = "Northstar Demo.app"
+            BlueprintName = "Northstar Demo"
+            ReferencedContainer = "container:Northstar Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1E6A4FD2E003BA5008C737D"
+            BuildableName = "Northstar Demo.app"
+            BlueprintName = "Northstar Demo"
+            ReferencedContainer = "container:Northstar Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
There are lots of spammy OS-level errors when coding in Xcode:
![image](https://github.com/user-attachments/assets/ec9c1db1-853c-437c-a9a4-84a6fc41cc42)

This also happens for simple Hello World-style apps.

Editing the scheme and adding `OS_ACTIVITY_MODE` as `disable` suppresses these annoying messages. Adding that environment variable adds the whole scheme to version control.

https://samwize.com/2022/10/29/reduce-xcode-debugger-logs/
https://ishanfx.medium.com/x-code-disable-annoying-system-logs-855c6ae18c7c