### PR TITLE
Keep display on while streaming positions

### DIFF
--- a/Northstar Demo/BasicUsageView.swift
+++ b/Northstar Demo/BasicUsageView.swift
@@ -146,7 +146,7 @@ struct BasicUsageView: View {
         do {
             try await positioning.start(userID: "User 123")
             self.positioning = positioning
-
+            UIApplication.shared.isIdleTimerDisabled = true
         } catch {
             alertMessage =
                 "We could not validate your API key.\n\nPlease check your internet connection, chosen region, API key and try again."
@@ -158,6 +158,7 @@ struct BasicUsageView: View {
 
     private func stop() {
         positioning?.stop()
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 }
 

--- a/Northstar Demo/MapView.swift
+++ b/Northstar Demo/MapView.swift
@@ -28,6 +28,7 @@ struct MapView: View {
         .task {
             do {
                 try await positioning.start()
+                UIApplication.shared.isIdleTimerDisabled = true
             } catch {
                 alertMessage =
                     "We could sign you in, but could not validate your API key.\n\nPlease check your API key and try again."
@@ -69,6 +70,7 @@ struct MapView: View {
                         Task {
                             do {
                                 try await positioning.start()
+                                UIApplication.shared.isIdleTimerDisabled = true
                             } catch {
                                 alertMessage =
                                     "Could not start positioning.\n\nPlease check your internet connection and try again."
@@ -84,6 +86,7 @@ struct MapView: View {
                 } else {
                     Button {
                         positioning.stop()
+                        UIApplication.shared.isIdleTimerDisabled = false
                     } label: {
                         Label(
                             "Stop Positioning",
@@ -120,6 +123,7 @@ struct MapView: View {
 
     private func logout() async {
         positioning.stop()
+        UIApplication.shared.isIdleTimerDisabled = false
 
         let response = await AF.request(
             "https://analytics-\(selectedRegion).walkbase.com/api/j/logout",


### PR DESCRIPTION
While I was gathering data in Motonet, the test iPhone used kept turning off the display after I while. I tried debugging it, but couldn't replicate it at the office. I then noticed that iOS keeps the display on if you keep looking at it; turning the iPhone away from my face replicated the problem. I added `UIKit.shared.isIdleTimerDisabled` toggles to keep the display on while streaming positions.